### PR TITLE
Allow custom sync config locations

### DIFF
--- a/src/app/CliTools/Console/Command/Sync/AbstractCommand.php
+++ b/src/app/CliTools/Console/Command/Sync/AbstractCommand.php
@@ -42,8 +42,9 @@ use Symfony\Component\Yaml\Yaml;
 abstract class AbstractCommand extends \CliTools\Console\Command\AbstractCommand
 {
 
-    const CONFIG_FILE = 'clisync.yml';
-    const GLOBAL_KEY  = 'GLOBAL';
+    const CONFIG_FILE   = 'clisync.yml';
+    const GLOBAL_KEY    = 'GLOBAL';
+    const CONFIG_ENVKEY = 'SYNC_CONFIG';
 
     /**
      * Config area
@@ -186,6 +187,12 @@ abstract class AbstractCommand extends \CliTools\Console\Command\AbstractCommand
             self::CONFIG_FILE,
             '.' . self::CONFIG_FILE,
         );
+
+        if (getenv(self::CONFIG_ENVKEY) !== FALSE) {
+            array_unshift($confFileList, getenv(self::CONFIG_ENVKEY));
+            array_unshift($confFileList, getenv(self::CONFIG_ENVKEY) . DIRECTORY_SEPARATOR . self::CONFIG_FILE);
+            array_unshift($confFileList, getenv(self::CONFIG_ENVKEY) . DIRECTORY_SEPARATOR . '.' . self::CONFIG_FILE);
+        }
 
         // Find configuration file
         $this->confFilePath = UnixUtility::findFileInDirectortyTree($confFileList);


### PR DESCRIPTION
Add a check for the environment variable "SYNC_CONFIG" which is
used to find a configuration file. This allows to place the files
at a different location than the acutal project, making re-use of
configurations easier.

Example

SYNC_CONFIG="$HOME/sync-projecta.yml" ct sync:server staging

The default behaviour is not altered by this change.
