### PR TITLE
Bugfix/umlautsupport osx

### DIFF
--- a/Documentation/Examples/clisync.yml
+++ b/Documentation/Examples/clisync.yml
@@ -54,6 +54,7 @@ GLOBAL:
         workdir: ""
 
         # Additional options ("-rlptD --delete-after --progress --human-readable" is already set)
+        # (" --iconv=UTF8-MAC,UTF8" is automatically set if OS is OSX to enable Umlauts support)
         opts: ""
 
         # exclude list/patterns for files and directories

--- a/src/app/CliTools/Console/Command/Sync/AbstractCommand.php
+++ b/src/app/CliTools/Console/Command/Sync/AbstractCommand.php
@@ -716,6 +716,11 @@ abstract class AbstractCommand extends \CliTools\Console\Command\AbstractCommand
             $command->addArgumentRaw($this->contextConfig->get('rsync.opts'));
         }
 
+        // Umlauts support for rsync
+        if (PhpUtility::getOsName() == 'Darwin') {
+            $command->addArgumentRaw(' --iconv=UTF8-MAC,UTF8');
+        }
+
         // Add file list (external file with --include-from option)
         if (!empty($filelist)) {
             $this->rsyncAddFileList($command, $filelist);

--- a/src/app/CliTools/Utility/PhpUtility.php
+++ b/src/app/CliTools/Utility/PhpUtility.php
@@ -199,4 +199,15 @@ class PhpUtility
 
         return $ret;
     }
+
+
+    /**
+     * Get operating system name
+     *
+     * @return string
+     */
+    public static function getOsName()
+    {
+        return php_uname('s');
+    }
 }


### PR DESCRIPTION
Umlauts in folders an files working now if rsync command is
executed under OSX

Fixed #69
