### PR TITLE
Substituted gzcat with 'gzip -dc'

### DIFF
--- a/src/app/CliTools/Console/Command/Mysql/RestoreCommand.php
+++ b/src/app/CliTools/Console/Command/Mysql/RestoreCommand.php
@@ -108,7 +108,7 @@ class RestoreCommand extends AbstractCommand
             case 'application/gzip':
             case 'application/x-gzip':
                 $output->writeln('<p>Using GZIP decompression</p>');
-                $commandFile->setCommand('gzcat');
+                $commandFile->setCommand('gzip')->addArgument('-dc');
                 break;
 
             case 'application/x-lzma':


### PR DESCRIPTION
Changing from bzip2 to gzip results in a huge performance gain (example: 250MB uncompressed is being compressed/decompressed 4-5 times as fast), but unfortunately Ubuntu (and thereby vagrant VM) doesn't come along with gzcat which is used for decompressing by the clitools.

Luckily, gzip that is used for compression, can be used as a substitute.

This is related to #99.
