### PR TITLE
Add --defaults-file option to mysql/mysqldump

### DIFF
--- a/Documentation/Examples/clisync.yml
+++ b/Documentation/Examples/clisync.yml
@@ -158,6 +158,8 @@ sync:
         mysql:
             username: typo3
             password: loremipsum
+            #hostname: db.example.com
+            #defaultsFile: /var/www/.my-custom.cnf
 
             # List of databases for synchronization
             #   examples:

--- a/src/app/CliTools/Console/Command/Sync/AbstractCommand.php
+++ b/src/app/CliTools/Console/Command/Sync/AbstractCommand.php
@@ -997,6 +997,12 @@ abstract class AbstractCommand extends \CliTools\Console\Command\AbstractDockerC
     protected function createRemoteMySqlCommand($database = null)
     {
         $command = new RemoteCommandBuilder('mysql');
+
+        // Add defaults-file
+        if ($this->contextConfig->exists('mysql.defaultsFile')) {
+            $command->addArgumentRaw($this->contextConfig->get('mysql.defaultsFile'));
+        }
+
         $command
             // batch mode
             ->addArgument('-B')
@@ -1090,6 +1096,11 @@ abstract class AbstractCommand extends \CliTools\Console\Command\AbstractDockerC
     protected function createRemoteMySqlDumpCommand($database = null)
     {
         $command = new RemoteCommandBuilder('mysqldump');
+
+        // Add defaults-file
+        if ($this->contextConfig->exists('mysql.defaultsFile')) {
+            $command->addArgumentRaw($this->contextConfig->get('mysql.defaultsFile'));
+        }
 
         // Add username
         if ($this->contextConfig->exists('mysql.username')) {

--- a/src/conf/clisync.yml
+++ b/src/conf/clisync.yml
@@ -159,6 +159,8 @@ sync:
         mysql:
             username: typo3
             password: loremipsum
+            #hostname: db.example.com
+            #defaultsFile: /var/www/.my-custom.cnf
 
             # List of databases for synchronization
             #   examples:


### PR DESCRIPTION
Sometimes it's not possible to place the .my.cnf file (containing the db password) into the users home folder on remote. So it'll be nice to specify a different location for that file.

The option mysql.mysqldump.options only works for mysqldump and not the mysql command that checks the db size and tablenames before syncing. Plus it doesn't add the --defaults-file option as first option which it needs to work properly.

So I introduced this option separately.