### PR TITLE
TYPO3 9 compatibility

### DIFF
--- a/src/app/CliTools/Console/Command/TYPO3/BeUserCommand.php
+++ b/src/app/CliTools/Console/Command/TYPO3/BeUserCommand.php
@@ -55,11 +55,10 @@ class BeUserCommand extends \CliTools\Console\Command\Mysql\AbstractCommand
                  InputArgument::OPTIONAL,
                  'Password'
              )
-             ->addOption(
-                 'plain',
-                 null,
-                 InputOption::VALUE_NONE,
-                 'Do not crypt password (non salted password)'
+             ->addArgument(
+                 'hash',
+                 InputArgument::OPTIONAL,
+                 'Choose the hashing algorithm for saving the password: md5, md5_salted, bcrypt, argon2i, argon2id'
              );
     }
 
@@ -103,18 +102,12 @@ class BeUserCommand extends \CliTools\Console\Command\Mysql\AbstractCommand
         $output->writeln('<p>Using pass: "' . htmlspecialchars($password) . '"</p>');
 
         // ##################
-        // Salting
+        // Password hashing
         // ##################
 
-        if ($input->getOption('plain')) {
-            // Standard md5
-            $password = Typo3Utility::generatePassword($password, Typo3Utility::PASSWORD_TYPE_MD5);
-            $this->output->writeln('<p>Generating plain (non salted) md5 password</p>');
-        } else {
-            // Salted md5
-            $password = Typo3Utility::generatePassword($password, Typo3Utility::PASSWORD_TYPE_MD5_SALTED);
-            $this->output->writeln('<p>Generating salted md5 password</p>');
-        }
+        $hash = $input->getArgument('hash');
+        list($password, $hash) = Typo3Utility::generatePassword($password, $hash);
+        $this->output->writeln('<p>Generating password with "' . htmlspecialchars($hash) . '" hashing algorithm</p>');
 
         // ##############
         // Loop through databases

--- a/src/app/CliTools/Utility/Typo3Utility.php
+++ b/src/app/CliTools/Utility/Typo3Utility.php
@@ -72,7 +72,8 @@ class Typo3Utility
 
             default:
                 $possibleAlgorithms = [];
-                defined('PASSWORD_ARGON2ID') && $possibleAlgorithms[PASSWORD_ARGON2ID] = self::PASSWORD_TYPE_ARGON2ID;
+                # Commented out since TYPO3 9.5 doesn't support argon2id yet
+                #defined('PASSWORD_ARGON2ID') && $possibleAlgorithms[PASSWORD_ARGON2ID] = self::PASSWORD_TYPE_ARGON2ID;
                 defined('PASSWORD_ARGON2I')  && $possibleAlgorithms[PASSWORD_ARGON2I]  = self::PASSWORD_TYPE_ARGON2I;
                 defined('PASSWORD_BCRYPT')   && $possibleAlgorithms[PASSWORD_BCRYPT]   = self::PASSWORD_TYPE_BCRYPT;
 


### PR DESCRIPTION
This patch enhances the command typo3:beuser by support of argon2i and argon2id hashing algorithms.