### PR TITLE
FIX: present docker-compose.yml prevents share:restore when 'docker' …

### DIFF
--- a/src/app/CliTools/Console/Command/Sync/AbstractCommand.php
+++ b/src/app/CliTools/Console/Command/Sync/AbstractCommand.php
@@ -624,7 +624,8 @@ abstract class AbstractCommand extends \CliTools\Console\Command\AbstractDockerC
             }
         }
 
-        if (!$answer) {
+        if (empty($answer)) {
+            $this->output->writeln('<error>Aborting</error>');
             throw new \CliTools\Exception\StopException(1);
         }
     }

--- a/src/app/CliTools/Console/Command/Sync/AbstractCommand.php
+++ b/src/app/CliTools/Console/Command/Sync/AbstractCommand.php
@@ -622,11 +622,11 @@ abstract class AbstractCommand extends \CliTools\Console\Command\AbstractDockerC
 
                 $answer = ConsoleUtility::questionYesNo('Continue anyway?', 'no');
             }
-        }
 
-        if (empty($answer)) {
-            $this->output->writeln('<error>Aborting</error>');
-            throw new \CliTools\Exception\StopException(1);
+            if (empty($answer)) {
+                $this->output->writeln('<error>Aborting</error>');
+                throw new \CliTools\Exception\StopException(1);
+            }
         }
     }
 

--- a/src/app/CliTools/Console/Command/Sync/AbstractCommand.php
+++ b/src/app/CliTools/Console/Command/Sync/AbstractCommand.php
@@ -608,17 +608,24 @@ abstract class AbstractCommand extends \CliTools\Console\Command\AbstractDockerC
         $dockerPath = \CliTools\Utility\DockerUtility::searchDockerDirectoryRecursive();
 
         if (!empty($dockerPath)) {
-            $this->output->writeln('<info>Running docker containers:</info>');
+            $this->output->writeln('<info>Found docker-compose.yml</info>');
 
-            // Docker instance found
-            $docker = new CommandBuilder('docker', 'ps');
-            $docker->executeInteractive();
+            try {
+                $this->output->writeln('<info>Trying to detect running docker containers ...</info>');
 
-            $answer = ConsoleUtility::questionYesNo('Are these running containers the right ones?', 'no');
+                $docker = new CommandBuilder('docker', 'ps');
+                $docker->executeInteractive();
 
-            if (!$answer) {
-                throw new \CliTools\Exception\StopException(1);
+                $answer = ConsoleUtility::questionYesNo('Are these running containers the right ones?', 'no');
+            } catch (\CliTools\Exception\CommandExecutionException $e) {
+                $this->output->writeln('<warning>' . $e->getMessage() . '</warning>');
+
+                $answer = ConsoleUtility::questionYesNo('Continue anyway?', 'no');
             }
+        }
+
+        if (!$answer) {
+            throw new \CliTools\Exception\StopException(1);
         }
     }
 


### PR DESCRIPTION
In case you wanna run `ct share:restore --mysql` from inside a docker container and there's a docker-compose.yml present that command quits with an exception because it fails to list all running docker containers. Because inside a docker container the `docker` executable is usually not available.

This patch makes sure the user is being asked in case `docker ps` fails whether or not they wanna continue.